### PR TITLE
Sort menu posts by Persian alphabet

### DIFF
--- a/posts/context_processors.py
+++ b/posts/context_processors.py
@@ -1,10 +1,25 @@
-from .models import Category
+from django.db.models import Prefetch, F, Value, CharField
+from django.db.models.functions import Replace, Lower
+from .models import Category, Post
 
 def categories(request):
-    """
-    Injects all Category objects into every template context
-    under the name 'all_categories'.
-    """
+    """Inject categories and their posts ordered alphabetically."""
+    normalized_posts = Post.objects.annotate(
+        norm_title=Lower(
+            Replace(
+                Replace(
+                    Replace(F("title"), Value("آ"), Value("ا"), output_field=CharField()),
+                    Value("أ"), Value("ا"), output_field=CharField(),
+                ),
+                Value("إ"), Value("ا"), output_field=CharField(),
+            )
+        )
+    ).order_by("norm_title")
+
+    qs = Category.objects.prefetch_related(
+        Prefetch("posts", queryset=normalized_posts)
+    )
+
     return {
-        "all_categories": Category.objects.all()
+        "all_categories": qs
     }


### PR DESCRIPTION
## Summary
- prefetch posts ordered by normalized Persian titles
- show categories with alphabetically ordered posts

## Testing
- `python manage.py test` *(fails: ModuleNotFoundError: No module named 'django')*