### PR TITLE
Add profile login/logout section

### DIFF
--- a/heartdoc/settings.py
+++ b/heartdoc/settings.py
@@ -146,6 +146,10 @@ except ImportError:
     # WhiteNoise not installed: use default staticfiles storage
     pass
 
+# Redirect after login/logout
+LOGIN_REDIRECT_URL = 'post_list'
+LOGOUT_REDIRECT_URL = 'post_list'
+
 # Default primary key field type
 # https://docs.djangoproject.com/en/5.2/ref/settings/#default-auto-field
 

--- a/heartdoc/urls.py
+++ b/heartdoc/urls.py
@@ -3,5 +3,6 @@ from django.urls import path, include
 
 urlpatterns = [
     path("admin/", admin.site.urls),
+    path("accounts/", include("django.contrib.auth.urls")),
     path("", include("posts.urls")),
 ]

--- a/templates/base.html
+++ b/templates/base.html
@@ -72,6 +72,15 @@
                placeholder="جستجو…" name="q" value="{{ request.GET.q }}">
         <button class="btn btn-outline-success" type="submit">جستجو</button>
       </form>
+      <!-- Profile section -->
+      <div class="ms-2">
+        {% if user.is_authenticated %}
+          <span class="me-2">{{ user.username }}</span>
+          <a href="{% url 'logout' %}" class="btn btn-outline-secondary btn-sm">خروج</a>
+        {% else %}
+          <a href="{% url 'login' %}" class="btn btn-outline-primary btn-sm">ورود</a>
+        {% endif %}
+      </div>
     </div>
   </nav>
   <!-- Offcanvas sidebar menu for categories and their posts -->

--- a/templates/registration/login.html
+++ b/templates/registration/login.html
@@ -1,0 +1,18 @@
+{% extends "base.html" %}
+
+{% block title %}ورود{% endblock %}
+
+{% block content %}
+<div class="row justify-content-center">
+  <div class="col-md-6">
+    <h2 class="mb-4 text-center">ورود به حساب کاربری</h2>
+    <form method="post">
+      {% csrf_token %}
+      {{ form.as_p }}
+      <div class="text-center">
+        <button type="submit" class="btn btn-primary">ورود</button>
+      </div>
+    </form>
+  </div>
+</div>
+{% endblock %}


### PR DESCRIPTION
## Summary
- add Django auth URL routes
- include login/logout profile links in navbar
- create simple login template
- redirect home after login/logout

## Testing
- `python manage.py check`
- `python manage.py test`

------
https://chatgpt.com/codex/tasks/task_e_683ee88214508330885af2e27a4fafd3